### PR TITLE
Typecast percentage toggle value correctly

### DIFF
--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -10,9 +10,9 @@ module Flipper
       end
 
       def open?(actor)
-        percentage = toggle.value
+        percentage = toggle.value.to_i
 
-        if percentage.nil?
+        if percentage == 0
           false
         else
           Zlib.crc32(actor.identifier.to_s) % 100 < percentage


### PR DESCRIPTION
- specifically, this does not work with the redis adapter as it passes its values as strings
- Unclear to me where this would be tested, but specs pass and hand testing works

We are using your two forks (this and redis adapter) in production because they are the only ones that work. Hoping your forks gets pulled into master soon... 